### PR TITLE
ci: PROD-186 ensure Gitleaks SARIF artifact exists

### DIFF
--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -122,6 +122,31 @@ jobs:
           GITLEAKS_ENABLE_COMMENTS: "false"
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
 
+      - name: Ensure Gitleaks SARIF exists
+        if: always()
+        shell: bash
+        run: |
+          if [ ! -s results.sarif ]; then
+            cat > results.sarif <<'SARIF'
+          {
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [
+              {
+                "tool": {
+                  "driver": {
+                    "name": "gitleaks",
+                    "informationUri": "https://github.com/gitleaks/gitleaks",
+                    "rules": []
+                  }
+                },
+                "results": []
+              }
+            ]
+          }
+          SARIF
+          fi
+
       - name: Upload Gitleaks SARIF to GitHub Security
         if: always()
         continue-on-error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -213,6 +213,31 @@ jobs:
           GITLEAKS_ENABLE_COMMENTS: "false"
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
 
+      - name: Ensure Gitleaks SARIF exists
+        if: always()
+        shell: bash
+        run: |
+          if [ ! -s results.sarif ]; then
+            cat > results.sarif <<'SARIF'
+          {
+            "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+            "version": "2.1.0",
+            "runs": [
+              {
+                "tool": {
+                  "driver": {
+                    "name": "gitleaks",
+                    "informationUri": "https://github.com/gitleaks/gitleaks",
+                    "rules": []
+                  }
+                },
+                "results": []
+              }
+            ]
+          }
+          SARIF
+          fi
+
       - name: Upload Gitleaks SARIF to GitHub Security
         if: always()
         continue-on-error: true


### PR DESCRIPTION
Release bug: the release workflow expects results.sarif, but a clean Gitleaks run can finish without creating that file. The upload step then fails even though there are no leaks

Fix: This fix adds an Ensure Gitleaks SARIF exists step that writes a valid empty SARIF only when Gitleaks did not produce one. It does not hide real leaks because the final failure step still checks steps.gitleaks_scan.outcome